### PR TITLE
Use new redux-saga syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "istanbul": "1.1.0-alpha.1",
     "mkdirp": "0.5.1",
     "mocha": "3.2.0",
-    "redux-saga": "0.14.3",
+    "redux-saga": "0.15.6",
     "rimraf": "2.6.1"
   }
 }

--- a/src/watchers.js
+++ b/src/watchers.js
@@ -1,5 +1,4 @@
-import { takeEvery } from 'redux-saga'
-import { call, put, take } from 'redux-saga/effects'
+import { call, put, take, takeEvery } from 'redux-saga/effects'
 
 import { EMIT, REQUEST } from './actions'
 import { createEventChannel } from './eventChannel'

--- a/src/watchers.js
+++ b/src/watchers.js
@@ -5,11 +5,11 @@ import { createEventChannel } from './eventChannel'
 import { handleEmit, handleRequest } from './workers'
 
 export function* watchEmits(socket) {
-  yield* takeEvery(EMIT, handleEmit, socket)
+  yield takeEvery(EMIT, handleEmit, socket)
 }
 
 export function* watchRequests(socket) {
-  yield* takeEvery(REQUEST, handleRequest, socket)
+  yield takeEvery(REQUEST, handleRequest, socket)
 }
 
 export function* watchRemote(socket, event = 'dispatch') {

--- a/test/watchers/watchEmits.js
+++ b/test/watchers/watchEmits.js
@@ -1,5 +1,5 @@
 import expect from 'expect'
-import { takeEvery } from 'redux-saga'
+import { takeEvery } from 'redux-saga/effects'
 
 import { EMIT, watchEmits } from '../../src'
 import { handleEmit } from '../../src/workers'

--- a/test/watchers/watchRequests.js
+++ b/test/watchers/watchRequests.js
@@ -1,5 +1,5 @@
 import expect from 'expect'
-import { takeEvery } from 'redux-saga'
+import { takeEvery } from 'redux-saga/effects'
 
 import { REQUEST, watchRequests } from '../../src'
 import { handleRequest } from '../../src/workers'


### PR DESCRIPTION
import { takeEvery } from 'redux-saga' has been deprecated in favor of import { takeEvery } from 'redux-saga/effects'.